### PR TITLE
Issue#86 

### DIFF
--- a/docs/datastructure.rst
+++ b/docs/datastructure.rst
@@ -80,6 +80,7 @@ We can store anything in the list, so first we are going to add another list  *b
 Above you can see how we used the *a.extend()* method to extend the list. To sort any list we have *sort()* method. The *sort()* method will only work if elements in the list are comparable. We will remove the list b from the list and then sort. 
 
 ::
+
     >>> a.remove(b)
     >>> a
     [45, 43624356, -3434, 1, 45, 23, 1, 111, 45, 56, 90]


### PR DESCRIPTION
As described in [Issue#86](https://github.com/kushaldas/pym/issues/86) `::` was visible in the build html because of missing blank line
