### PR TITLE
Update installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -18,11 +18,23 @@ On GNU/Linux
 
 Install the latest Python from the distribution's repository.
 
-For Fedora
+For Fedora 23 and above.
+
+::
+
+    [user@host]$ sudo dnf install python3
+
+For Fedora 22 and bellow.
 
 ::
 
     [user@host]$ sudo yum install python3
+
+From epel7 (RHEL7, CentOS7, SL7).
+
+::
+
+    [user@host]$ sudo yum install python34
 
 For Debian
 


### PR DESCRIPTION
Fedora 23 and above are using dnf and not yum, in RHEL7 and CentOS7 now there is available python34 via the epel repo:

http://stackoverflow.com/questions/8087184/installing-python3-on-rhel
