### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,4 +2,4 @@ Python for you and me
 =====================
 A fast paced Python book for students.
 
-Read it `here <http://pymbook.readthedocs.org/en/latest>`_.
+Read it `here <https://pymbook.readthedocs.io/en/latest>`_.

--- a/docs/file.rst
+++ b/docs/file.rst
@@ -129,7 +129,7 @@ In real life scenarios we should try to use `with` statement. It will take care 
         platforms = ["Linux"],
         author="Kushal Das",
         author_email="kushaldas@gmail.com",
-        url="http://pymbook.readthedocs.org/en/latest/",
+        url="https://pymbook.readthedocs.io/en/latest/",
         license = "http://www.gnu.org/copyleft/gpl.html",
         packages=find_packages()
         )

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ Welcome to Python for you and me
 
 This is a simple book to learn Python programming language, it is for the programmers who are new to Python.
 
-The Python 2.x version of the same book can be found `here <http://pymbook.readthedocs.org/en/latest/>`_.
+The Python 2.x version of the same book can be found `here <https://pymbook.readthedocs.io/en/latest/>`_.
 
 Contents:
 

--- a/docs/projectstructure.rst
+++ b/docs/projectstructure.rst
@@ -95,7 +95,7 @@ or installing the software.
         platforms = ["Linux"],
         author="Kushal Das",
         author_email="kushaldas@gmail.com",
-        url="http://pymbook.readthedocs.org/en/latest/",
+        url="https://pymbook.readthedocs.io/en/latest/",
         license = "MIT",
         packages=find_packages()
         )


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
