### PR TITLE
Avoid using `all` as variable name

### DIFF
--- a/docs/igd.rst
+++ b/docs/igd.rst
@@ -253,8 +253,8 @@ We can do the same using a shell command *tail -f /var/log/cron |grep anacron*
 ::
 
     >>> jobtext = 'anacron'
-    >>> all = (line for line in open('/var/log/cron', 'r') )
-    >>> job = ( line for line in all if line.find(jobtext) != -1)
+    >>> all_lines = (line for line in open('/var/log/cron', 'r') )
+    >>> job = ( line for line in all_lines if line.find(jobtext) != -1)
     >>> text = next(job)
     >>> text
     "May  6 12:17:15 dhcp193-104 anacron[23052]: Job `cron.daily' terminated\n"


### PR DESCRIPTION
Minor fix for changing the use of `all`  as variable name, since it is already a built-in in standard library: https://docs.python.org/2/library/functions.html#all