### PR TITLE
Typo error corrected in installation Chapter

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,7 +21,7 @@ Install the latest Python from the distribution's repository.
 For Fedora 23 and above Python3 is in the system by default.
 
 
-For Fedora 22 and bellow.
+For Fedora 22 and below.
 
 ::
 


### PR DESCRIPTION
Fix #122 

- Correct the word `bellow` by `below`.
