### PR TITLE
Correct Spelling of Lose

### DIFF
--- a/docs/looping.rst
+++ b/docs/looping.rst
@@ -445,7 +445,7 @@ We will see more example of *break* and *continue* later in the book.
 Game of sticks
 ==============
 
-This is a very simple game of sticks. There are 21 sticks, first the user picks number of sticks between 1-4, then the computer picks sticks(1-4). Who ever will pick the last stick will loose. Can you find out the case when the user will win ?
+This is a very simple game of sticks. There are 21 sticks, first the user picks number of sticks between 1-4, then the computer picks sticks(1-4). Who ever will pick the last stick will lose. Can you find out the case when the user will win ?
 
 ::
 
@@ -453,13 +453,13 @@ This is a very simple game of sticks. There are 21 sticks, first the user picks 
     sticks = 21
 
     print("There are 21 sticks, you can take 1-4 number of sticks at a time.")
-    print("Whoever will take the last stick will loose")
+    print("Whoever will take the last stick will lose")
 
     while True:
         print("Sticks left: " , sticks)
         sticks_taken = int(input("Take sticks(1-4):"))
         if sticks == 1:
-            print("You took the last stick, you loose")
+            print("You took the last stick, you lose")
             break
         if sticks_taken >= 5 or sticks_taken <= 0:
             print("Wrong choice")


### PR DESCRIPTION
Use of correct word lose.
https://www.thefreedictionary.com/lose

Signed-off-by: Akshay Gaikwad <akgaikwad001@gmail.com>