### PR TITLE
[conf.py] Fix unicode error

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -297,6 +297,6 @@ epub_copyright = u'2008-2017, Kushal Das'
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'python': ('http://docs.python.org/3', None)}
-latex_preamble = """
+latex_preamble = r"""
 \usepackage{upquote}
 """


### PR DESCRIPTION
Running "make html" command to build docs, throws following error
message:
```
Configuration error:
There is a syntax error in your configuration file: (unicode error)
'unicodeescape' codec can't decode bytes in position 1-2: truncated
\uXXXX escape (conf.py, line 302)

make: *** [Makefile:45: html] Error 2
```