### PR TITLE
fix/collections: Fix formatting issue in "defaultdict example" section

### DIFF
--- a/docs/collections.rst
+++ b/docs/collections.rst
@@ -60,6 +60,7 @@ defaultdict example
 -------------------
 
 ::
+
     >>> from collections import defaultdict
     >>> s = [('yellow', 1), ('blue', 2), ('yellow', 3), ('blue', 4), ('red', 1)]
     >>> d = defaultdict(list)


### PR DESCRIPTION
Due to missing a newline between code block directive (::) and code
block, Sphinx couldn't format the whole code block, properly.