### PR TITLE
- Fixed typos

### DIFF
--- a/docs/_themes/README.rst
+++ b/docs/_themes/README.rst
@@ -2,7 +2,7 @@ krTheme Sphinx Style
 ====================
 
 This repository contains sphinx styles Kenneth Reitz uses in most of
-his projects. It is a drivative of Mitsuhiko's themes for Flask and Flask related
+his projects. It is a derivative of Mitsuhiko's themes for Flask and Flask related
 projects.  To use this style in your Sphinx documentation, follow
 this guide:
 

--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -121,7 +121,7 @@ Unique class level variables
 All the values stored in the instance via `self.` are data inside of an
 instance. Each instance of the class can have different values for given
 attribute (anything we access via . is also known as attribute). But, when we
-define an variable in the class level, that is same accross all objects. In
+define an variable in the class level, that is same across all objects. In
 the following example, we define a class called `Point`, and we also have a
 special class level variable called `style` in it. After we create 2 objects
 of type `Point`, we can see that both has the same `class` attribute `style`
@@ -530,7 +530,7 @@ Do you remember the `with` statement from the `files` chapter? Where we used a
 context manager to make sure that the file is closed after we are done? The
 same style is used in many places where we want the resources to be cleaned up
 after the work is done; sometimes we want to call some extra functions when we are
-done. We can write our own context manager in our classs using `__enter__` and
+done. We can write our own context manager in our class using `__enter__` and
 `__exit__` methods.
 
 For example, we will create a new class called `TimeLog` which in turn will

--- a/docs/flask.rst
+++ b/docs/flask.rst
@@ -263,7 +263,7 @@ function linked to. In addition it takes care of where the application is
 deployed.
 
 For example, if you website is deployed at: ``/myapp/`` flask will automatically
-happend ``/myapp/`` to all links without the need for you to specify it.
+happened ``/myapp/`` to all links without the need for you to specify it.
 
 To create a link in a template, flask relies on the function ``url_for()``. This
 function takes as first argument the function you want to call (link to). The

--- a/docs/hardwaresimulation.rst
+++ b/docs/hardwaresimulation.rst
@@ -66,7 +66,7 @@ Turning on all NeoPixels on the board with Red colour
         cpx.pixels.fill(RED)
 
 On the top of the code, we are writing a line starting with **from** to get the Python module
-which can interact wtih the device, as **cpx**. Next line, we are also importing *time* module,
+which can interact with the device, as **cpx**. Next line, we are also importing *time* module,
 which we will use later.
 
 Then we defined a colour Red in the *RED* variable as a (R, G, B) tuple.

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -248,7 +248,7 @@ Now your Python installation comes with different modules installed, you can use
 
 The above example shows how to get the list of all installed modules in your system. I am not pasting them here as it is a big list in my system :)
 
-You can also use *help()* function in the interpeter to find documentation about any module/classes. Say you want to know all available methods in strings, you can use the following method
+You can also use *help()* function in the interpreter to find documentation about any module/classes. Say you want to know all available methods in strings, you can use the following method
 
 ::
 

--- a/docs/virtualenv.rst
+++ b/docs/virtualenv.rst
@@ -215,7 +215,7 @@ on the package index. The exact version details of the packages are stored in
 the *Pipfile.lock* file, it is in machine readable `JSON
 <https://en.wikipedia.org/wiki/JSON>`_ format.
 
-Remember to install any dependency for your project using **pipenv** comamnd,
+Remember to install any dependency for your project using **pipenv** command,
 that will automatically update your *Pipfile* and *Pipfile.lock* file. If you
 have any dependency which is only required for the development, you can
 install them marked as *dev-packages*. In the following example I am installing


### PR DESCRIPTION
Fixed typos [issues151](https://github.com/kushaldas/pym/issues/151) :
- [x] In `docs/hardwaresimulation.rst` observed `wtih`, now replaced with `with`.
- [x] In  `docs/modules.rst` observed `interpeter`, now replaced with `interpreter`.
- [x] In  `docs/flask.rst` and observed `happend` now replaced with `happened`.
- [x] In `docs/_themes/README.rst` and observed `drivative`, now replaced with `derivative`.
- [x] In `docs/virtualenv.rst` and observed `comamnd`, now replaced with `command`.
- [x] In `docs/classes.rst` and observed `classs`, now replaced with `class`.
- [x] In `docs/classes.rst` and observed `accross`, now replaced with `across`.
- [ ] In `docs/thebeginning.rst` and does not contains `terinal` so no change required 
